### PR TITLE
Remove references to XOR-based links

### DIFF
--- a/src/chain/block_identifier.rs
+++ b/src/chain/block_identifier.rs
@@ -21,8 +21,10 @@ use data::DataIdentifier;
 
 /// Ledger type (delete or keep)
 pub type Ledger = bool;
-/// Represents the xored close group for the new group on churn etc.
-/// This is signed by each group member.
+
+/// Hash of the public keys of all group members (keys are lexicographically sorted before hashing).
+///
+/// Each node in the group signs this to form a `Proof`.
 pub type LinkDescriptor = [u8; 32];
 
 /// Data identifiers for use in a data Chain.
@@ -35,11 +37,8 @@ pub enum BlockIdentifier {
     ImmutableData([u8; 32]),
     ///           hash     name (identity + tag) (stored localy as name in data store)
     StructuredData([u8; 32], DataIdentifier),
-    /// This array represents **this nodes** current close group
-    /// The array is all nodes xored together
-    /// This is unique to this node, but known by all nodes connected to it
-    /// in this group.
-    Link(LinkDescriptor), // hash of group (all current close group id's)
+    /// Hash of group members' public keys (see `LinkDescriptor`).
+    Link(LinkDescriptor),
 }
 
 impl BlockIdentifier {


### PR DESCRIPTION
Link descriptors used to be the XOR of all node IDs in the group, but this would be insecure and was fixed by Andreas in commit:

b9cf5cc1f26cb60bc0858875ce1a861151ba6b6f

I found this a little confusing while reading, so figured I may as well fix it up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dirvine/data_chain/9)
<!-- Reviewable:end -->
